### PR TITLE
Allow promise libraries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+.idea

--- a/index.js
+++ b/index.js
@@ -17,6 +17,10 @@ aws.Request.prototype.promise = function() {
   }.bind(this));
 };
 
-aws.Promise = undefined;
+if (aws.Promise) {
+  throw new Error('Refusing to overwrite aws library property');
+} else {
+  aws.Promise = undefined;
+}
 
 module.exports = aws;

--- a/index.js
+++ b/index.js
@@ -1,20 +1,23 @@
 // taken from https://github.com/taskcluster/taskcluster-queue/blob/0dd2b45b860836a2ef6c651c5499c9abfb5670ad/utils/aws-sdk-promise.js
 var aws = require('aws-sdk');
-var Promise = require('promise');
 
 // XXX: This is a terrible hack but it should not break anything in horrible
 // ways.
 aws.Request.prototype.promise = function() {
-  return new Promise(function(accept, reject) {
-    this.on('complete', function(response) {
+  var that = this;
+  var Prom = aws.Promise || require('promise');
+  return new Prom(function(accept, reject) {
+    that.on('complete', function(response) {
       if (response.error) {
         reject(response.error);
       } else {
         accept(response);
       }
     });
-    this.send();
-  }.bind(this));
+    that.send();
+  });
 };
+
+aws.Promise = undefined;
 
 module.exports = aws;

--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ var aws = require('aws-sdk');
 // ways.
 aws.Request.prototype.promise = function() {
   var that = this;
-  var Prom = aws.Promise || require('promise');
+  var Prom = aws.Promise || Promise || require('promise');
   return new Prom(function(accept, reject) {
     that.on('complete', function(response) {
       if (response.error) {

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ var aws = require('aws-sdk');
 // XXX: This is a terrible hack but it should not break anything in horrible
 // ways.
 aws.Request.prototype.promise = function() {
-  var Prom = aws.Promise || Promise || require('promise');
+  var Prom = aws.Promise || global.Promise || window.Promise || require('promise');
   return new Prom(function(accept, reject) {
     this.on('complete', function(response) {
       if (response.error) {

--- a/index.js
+++ b/index.js
@@ -4,18 +4,17 @@ var aws = require('aws-sdk');
 // XXX: This is a terrible hack but it should not break anything in horrible
 // ways.
 aws.Request.prototype.promise = function() {
-  var that = this;
   var Prom = aws.Promise || Promise || require('promise');
   return new Prom(function(accept, reject) {
-    that.on('complete', function(response) {
+    this.on('complete', function(response) {
       if (response.error) {
         reject(response.error);
       } else {
         accept(response);
       }
     });
-    that.send();
-  });
+    this.send();
+  }.bind(this));
 };
 
 aws.Promise = undefined;

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Hack for adding the .promise() method to all aws-sdk request objects",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "mocha"
   },
   "repository": {
     "type": "git",
@@ -21,6 +21,11 @@
     "url": "https://github.com/taskcluster/aws-sdk-promise/issues"
   },
   "homepage": "https://github.com/taskcluster/aws-sdk-promise",
+  "devDependencies": {
+    "mocha": "^2.3.4",
+    "must": "^0.13.1",
+    "rewire": "^2.5.1"
+  },
   "dependencies": {
     "promise": "^6.1.0",
     "aws-sdk": "^2.1.5"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-sdk-promise",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Hack for adding the .promise() method to all aws-sdk request objects",
   "main": "index.js",
   "scripts": {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -13,4 +13,11 @@ describe('library', function () {
     ec2.describeAccountAttributes().promise()
         .must.have.property('then');
   });
+
+  it('should allow custom Promise constructor', function () {
+    var fakePromise = {custom: "promise"};
+    aws.Promise = function () { return fakePromise };
+    ec2.describeAccountAttributes().promise()
+        .must.equal(fakePromise);
+  })
 });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,0 +1,16 @@
+"use strict";
+require('must');
+var rewire = require('rewire');
+
+describe('library', function () {
+  var aws, ec2;
+  beforeEach(function () {
+    aws = rewire('../');
+    ec2 = new aws.EC2();
+  });
+
+  it('should promisify functions', function () {
+    ec2.describeAccountAttributes().promise()
+        .must.have.property('then');
+  });
+});


### PR DESCRIPTION
I wanted this library to return Q promises for my own project, with this change user can pass in a custom constructor via `.Promise` property.
